### PR TITLE
Added AppDelegate category with launch override

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -127,6 +127,8 @@
           </feature>
         </config-file>
         <header-file src="src/ios/cordova-plugin-geofence-Bridging-Header.h" />
+        <header-file src="src/ios/AppDelegate+LocationStartup.h" />
+        <source-file src="src/ios/AppDelegate+LocationStartup.m" />
         <source-file src="src/ios/GeofencePlugin.swift"/>
         <source-file src="src/ios/SwiftData.swift"/>
         <source-file src="src/ios/SwiftyJson.swift"/>

--- a/src/ios/AppDelegate+LocationStartup.h
+++ b/src/ios/AppDelegate+LocationStartup.h
@@ -1,0 +1,13 @@
+//
+//  AppDelegate+LocationStartup.h
+//  GeoFencev2
+//
+//  Created by Colin Humber on 2017-05-05.
+//
+//
+
+#import "AppDelegate.h"
+
+@interface AppDelegate (LocationStartup)
+
+@end

--- a/src/ios/AppDelegate+LocationStartup.m
+++ b/src/ios/AppDelegate+LocationStartup.m
@@ -1,0 +1,46 @@
+//
+//  AppDelegate+LocationStartup.m
+//  GeoFencev2
+//
+//  Created by Colin Humber on 2017-05-05.
+//
+//
+
+#import "AppDelegate+LocationStartup.h"
+#import "GeoFencev2-Swift.h"
+#import <objc/runtime.h>
+
+@interface AppDelegate()
+@property (strong) GeoNotificationManager *geoManager;
+
+@end
+
+@implementation AppDelegate (LocationStartup)
+
++ (void)load {
+    static dispatch_once_t once_token;
+    dispatch_once(&once_token,  ^{
+        SEL applicationDidFinishLaunchingSelector = @selector(application:didFinishLaunchingWithOptions:);
+        SEL geoApplicationDidFinishLaunchingSelector = @selector(geo_application:didFinishLaunchingWithOptions:);
+        Method originalMethod = class_getInstanceMethod(self, applicationDidFinishLaunchingSelector);
+        Method extendedMethod = class_getInstanceMethod(self, geoApplicationDidFinishLaunchingSelector);
+        method_exchangeImplementations(originalMethod, extendedMethod);
+    });
+}
+
+- (BOOL)geo_application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    BOOL didLaunch = [self geo_application:application didFinishLaunchingWithOptions:launchOptions];
+
+    self.geoManager = [[GeoNotificationManager alloc] init];
+
+    if (launchOptions[UIApplicationLaunchOptionsLocationKey]) {
+        self.geoManager = [[GeoNotificationManager alloc] init];
+        
+        [self.geoManager.locationManager startUpdatingLocation];
+        [self.geoManager.locationManager startMonitoringSignificantLocationChanges];
+    }
+
+    return didLaunch;
+}
+
+@end


### PR DESCRIPTION
The category swizzles -application:didFinishLaunchingWithOptions: to handle when the app launches fresh due to a location change. This is swizzled to remove the need to create a custom AppDelegate class. However, if the Cordova-generated UIApplicationDelegate class is not named AppDelegate, this won't work and will likely cause build issues.